### PR TITLE
Удаление круглых скобок из имени файла.

### DIFF
--- a/core/components/fastuploadtv/processors/browser/file/upload.class.php
+++ b/core/components/fastuploadtv/processors/browser/file/upload.class.php
@@ -150,6 +150,7 @@ private function prepareFiles($prefix){
         foreach($files as &$file){
             $pathInfo = pathinfo($file['name']);
             $filename = ($translit) ? $doc->cleanAlias($pathInfo['filename']) : $pathInfo['filename'];
+            $filename=str_replace(array(')','('),array('',''),$filename);
             $file['name'] = $this->parsePlaceholders($prefix.$filename.'.'. $pathInfo['extension']);
         };
         return $files;


### PR DESCRIPTION
Удаление круглых скобок из имени файла.
Если в имени файла есть круглые скобки и потом этот tv используется как background-image, то с круглыми скобками не загружается рисунок.
