### PR TITLE
Исправление ошибки "файл уже существует"

### DIFF
--- a/.hgtags
+++ b/.hgtags
@@ -1,0 +1,1 @@
+4aef074ae0a45e4d5fe381acb91bee7fe8438c92 hotfix

--- a/core/components/fastuploadtv/elements/plugins/plugin.FastUploadTV.php
+++ b/core/components/fastuploadtv/elements/plugins/plugin.FastUploadTV.php
@@ -43,8 +43,10 @@ switch ($modx->event->name) {
                     $filename = trim($filename, '-'); // remove first symbol "-"
                     
                     $newPath = $filename . '.' . strtolower($pathInfo['extension']);
-                    
-                    $source->renameObject($oldPath, $newPath);
+
+                    if ($newPath !== $file['name']) {
+                        $source->renameObject($oldPath, $newPath);
+                    }
                 }
             }
         }


### PR DESCRIPTION
При загрузке файла с именем не требующее транслитерации через  файловый менеджер в админке возникала ошибка "Файл уже существует". 