### PR TITLE
Системная настройка для удаления файла

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -5,7 +5,8 @@ $s = array(
     'check_resid' => true,
     'preview_width_max' => 150,
     'preview_height_max' => 100,
-    'random_lenght' => 6
+    'random_lenght' => 6,
+    'remove_file' => false
 );
 
 $settings = array();

--- a/assets/components/fastuploadtv/mgr/js/FastUploadTV.form.FastUploadTVField.js
+++ b/assets/components/fastuploadtv/mgr/js/FastUploadTV.form.FastUploadTVField.js
@@ -240,23 +240,27 @@ Ext.extend(FastUploadTV.form.FastUploadTVField,Ext.form.TextField,{
     ,onClearButtonClick: function(){
         var _this = this;
 
-        MODx.msg.confirm({
-            text: _('file_confirm_remove')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'browser/file/remove'
-                ,file: this.value
-                ,wctx: MODx.ctx || 'web'
-                ,source: this.ms_id
-            }
-            ,listeners: {
-                success: {
-                    fn: function() {
-                      _this.onUploadSuccess({result:{message:''}});
+        if (MODx.config['fastuploadtv.remove_file']) {
+            MODx.msg.confirm({
+                text: _('file_confirm_remove')
+                ,url: MODx.config.connector_url
+                ,params: {
+                    action: 'browser/file/remove'
+                    ,file: this.value
+                    ,wctx: MODx.ctx || 'web'
+                    ,source: this.ms_id
+                }
+                ,listeners: {
+                    success: {
+                        fn: function() {
+                          _this.onUploadSuccess({result:{message:''}});
+                        }
                     }
                 }
-            }
-        });
+            });
+        } else {
+            _this.onUploadSuccess({result:{message:''}});
+        }
     }
 
 

--- a/core/components/fastuploadtv/lexicon/en/default.inc.php
+++ b/core/components/fastuploadtv/lexicon/en/default.inc.php
@@ -38,3 +38,4 @@ $_lang['setting_fastuploadtv.check_resid_desc'] = 'Recommended!';
 $_lang['setting_fastuploadtv.preview_width_max'] = 'Max width of the thumbnail';
 $_lang['setting_fastuploadtv.preview_height_max'] = 'Max height of the thumbnails';
 $_lang['setting_fastuploadtv.random_lenght'] = 'The length of the placeholder {rand}';
+$_lang['setting_fastuploadtv.remove_file'] = 'Hard remove file';

--- a/core/components/fastuploadtv/lexicon/ru/default.inc.php
+++ b/core/components/fastuploadtv/lexicon/ru/default.inc.php
@@ -40,3 +40,4 @@ $_lang['setting_fastuploadtv.preview_width_max_desc'] = 'Максимальна�
 $_lang['setting_fastuploadtv.preview_height_max'] = 'Высота миниатюры';
 $_lang['setting_fastuploadtv.preview_height_max_desc'] = 'Максмальная высота миниатюры (в админ-панели)';
 $_lang['setting_fastuploadtv.random_lenght'] = 'Длина плейсхолдера {rand}';
+$_lang['setting_fastuploadtv.remove_file'] = 'Удалять файл физически';


### PR DESCRIPTION
Логичным кажется создание системной настройки, которая влияет на поведение. Не всегда нужно, чтобы файл физически удалялся. Пусть пользователи сами решают, как дополнение должно вести себя.

Кроме того, нужно не забыть о тех, кто просто обновляет дополнение. Для них поведение не должно измениться, значит, эту настройку придётся выставить в значение `false`

В этом Pull request добавляется системная настройка `remove_file`. И если её включить в значение `true`, то файл будет удаляться физически.