### PR TITLE
Remove a not needed check

### DIFF
--- a/core/components/fastuploadtv/processors/browser/file/upload.class.php
+++ b/core/components/fastuploadtv/processors/browser/file/upload.class.php
@@ -24,10 +24,6 @@ class fastBrowserFileUploadProcessor extends modBrowserFileUploadProcessor {
     }
     
     public function process() {
-        if (!$this->getSource()) {
-            return $this->failure($this->modx->lexicon('permission_denied'));
-        }
-        
         // Check a file has been uploaded
         if (count($_FILES) < 1) {
             return $this->failure($this->modx->lexicon('fastuploadtv.err_file_ns'));


### PR DESCRIPTION
The check for the source bases on the TV source and happens later.