### PR TITLE
Set the working context on base of the current resource

### DIFF
--- a/core/components/fastuploadtv/processors/browser/file/upload.class.php
+++ b/core/components/fastuploadtv/processors/browser/file/upload.class.php
@@ -176,7 +176,7 @@ class fastBrowserFileUploadProcessor extends modBrowserFileUploadProcessor {
         $this->source = modMediaSource::getDefaultSource($this->modx,$this->getProperty('ms_id'));
 
         $resource = $this->modx->getObject('modResource', $this->getProperty('res_id'));
-        $wctx = ($resource->get('context_key') != 'web') ? $resource->get('context_key') : '';
+        $wctx = ($resource && $resource->get('context_key') != 'web') ? $resource->get('context_key') : '';
         if ($wctx) {
                 $this->source->setProperty('wctx', $wctx);
         }


### PR DESCRIPTION
and don't use the source defined in the TV. That way the upload works almost the same as the MODX browser/file/upload processor.

This code has no issues anymore with restricted media source access.